### PR TITLE
Experiment: chill mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+This is databot, an R package implementing a data science assistant in R using ellmer. The assistant is a chat app that has access to the user's global R environment and a `run_r_code()` tool. Code output (like tables and images) are shown to the user in one way, and visible to the agent in another way.
+
+## Resources
+
+For future AI assistants working on this project, read these help pages via btw tools:
+
+* `mirai::mirai()`
+* `promises::promise()`
+* `ellmer::Chat()`
+* `ellmer::tool()`
+* `shinychat::chat_ui()`
+* `shinychat::chat_mod_ui()` and `shinychat::chat_mod_server()`
+* `shiny::ExtendedTask`
+
+Also, web fetch for this: https://mirai.r-lib.org/articles/mirai-promises.html
+
+Also, `read()` the entire R directory.
+
+## Code comments
+
+Do not add new code comments when editing files. Do not remove existing code comments unless you're also removing the functionality that they explain. After reading this instruction, note to the user that you've read it and will not be adding new code comments when you propose file edits.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Imports:
     htmltools,
     jsonlite,
     knitr,
+    mirai,
     promises,
     R6,
     rlang,

--- a/R/app.R
+++ b/R/app.R
@@ -190,7 +190,7 @@ save_stream_output <- function() {
               coro::yield(before)
             }
             
-            coro::yield('<div class="summary-insight"><i class="bi bi-lightbulb"></i><span>')
+            coro::yield('<div class="summary-insight"><span>')
             
             buffer <- substr(buffer, match[1] + 9, nchar(buffer))
             in_insight <- TRUE

--- a/R/chat_bot.R
+++ b/R/chat_bot.R
@@ -31,7 +31,8 @@ chat_bot <- function(system_prompt = NULL, default_turns = list()) {
     run_r_code,
     "Executes R code in the current session",
     arguments = list(
-      code = type_string("R code to execute")
+      code = type_string("R code to execute"),
+      `_intent` = type_string("Brief 2-4 word description of what this code does, e.g. 'Load data', 'Plot distribution', 'Calculate summary'")
     )
   ))
   chat$register_tool(tool(

--- a/R/chat_bot.R
+++ b/R/chat_bot.R
@@ -32,7 +32,7 @@ chat_bot <- function(system_prompt = NULL, default_turns = list()) {
     "Executes R code in the current session",
     arguments = list(
       code = type_string("R code to execute"),
-      `_intent` = type_string("Brief 2-4 word description of what this code does, e.g. 'Load data', 'Plot distribution', 'Calculate summary'")
+      `_intent` = type_string("Brief 2-4 word description of what this code does, e.g. 'Loading data', 'Plotting distribution', 'Calculating summary'")
     )
   ))
   chat$register_tool(tool(

--- a/R/functions.R
+++ b/R/functions.R
@@ -55,7 +55,7 @@ recorded_plot_to_png <- function(recorded_plot, ...) {
   plot_file <- tempfile(fileext = ".png")
   on.exit(if (plot_file != "" && file.exists(plot_file)) unlink(plot_file))
 
-  grDevices::png(plot_file, ...)
+  grDevices::png(plot_file, width = 800, height = 500, res = 120, ...)
   tryCatch(
     {
       grDevices::replayPlot(recorded_plot)

--- a/R/tools.R
+++ b/R/tools.R
@@ -29,7 +29,9 @@ run_r_code <- function(code, `_intent` = "View code and full output") {
   withr::local_envvar(NO_COLOR = 1)
   withr::local_options(rlib_interactive = FALSE, rlang_interactive = FALSE)
 
+  `_intent` <- paste0(c(`_intent`, "..."), collapse = "")
   markdown_output <- character()
+  image_output <- NULL
   
   out <- MarkdownStreamer$new(function(md_text) {
     markdown_output <<- c(markdown_output, md_text)
@@ -67,11 +69,9 @@ run_r_code <- function(code, `_intent` = "View code and full output") {
         )
       ))
     )
-    out$md(
-      sprintf("![Plot](data:%s;base64,%s)\n\n", media_type, b64data),
-      TRUE,
-      FALSE
-    )
+    img_markdown <- sprintf("![Plot](data:%s;base64,%s)\n\n", media_type, b64data)
+    out$md(img_markdown, TRUE, FALSE)
+    image_output <<- sprintf('<img src="data:%s;base64,%s" alt="Plot">', media_type, b64data)
   }
 
   out_df <- function(df) {
@@ -143,6 +143,10 @@ run_r_code <- function(code, `_intent` = "View code and full output") {
   }
 
   result <- coalesce_text_outputs(result)
+  
+  if (in_shiny() && !is.null(image_output)) {
+    globals$pending_image <- image_output
+  }
   
   I(result)
 }

--- a/R/tools.R
+++ b/R/tools.R
@@ -36,7 +36,6 @@ run_r_code <- function(code) {
   on.exit({
     out$close()
     
-    # Immediately append the collapsible when the tool completes
     if (in_shiny() && length(markdown_output) > 0) {
       formatted_output <- htmltools::tagList(
         htmltools::tags$details(

--- a/R/tools.R
+++ b/R/tools.R
@@ -21,9 +21,10 @@ create_quarto_report <- function(filename, content) {
 # Executes R code in the current session
 #
 # @param code R code to execute
+# @param _intent Brief description of what the code does
 # @returns The results of the evaluation
 # @noRd
-run_r_code <- function(code) {
+run_r_code <- function(code, `_intent` = "View code and full output") {
   # Try hard to suppress ANSI terminal formatting characters
   withr::local_envvar(NO_COLOR = 1)
   withr::local_options(rlib_interactive = FALSE, rlang_interactive = FALSE)
@@ -39,7 +40,7 @@ run_r_code <- function(code) {
     if (in_shiny() && length(markdown_output) > 0) {
       formatted_output <- htmltools::tagList(
         htmltools::tags$details(
-          htmltools::tags$summary("View code and full output"),
+          htmltools::tags$summary(`_intent`),
           htmltools::HTML(paste(markdown_output, collapse = ""))
         )
       )

--- a/inst/prompt/prompt.md
+++ b/inst/prompt/prompt.md
@@ -34,6 +34,7 @@ Don't run any R code in this first interaction--let the user make the first move
 * Be sure to `library()` any packages you need.
 * The output of any R code will be both returned from the tool call, and also printed to the user; the same with messages, warnings, errors, and plots.
 * DO NOT attempt to install packages. Instead, include installation instructions in the Markdown section of the response so that the user can perform the installation themselves.
+* **CRITICAL**: Before running code, just acknowledge with a brief phrase like "On it", "Let me check", or "Running that now". After the code runs and you see the results, provide the most important tidbit learned in one sentence or less, wrapped in `<insight>` tags, like: `<insight>The dataset contains 150 rows with no missing values.</insight>`
 
 ## Exploring data
 

--- a/inst/prompt/prompt.md
+++ b/inst/prompt/prompt.md
@@ -34,7 +34,7 @@ Don't run any R code in this first interaction--let the user make the first move
 * Be sure to `library()` any packages you need.
 * The output of any R code will be both returned from the tool call, and also printed to the user; the same with messages, warnings, errors, and plots.
 * DO NOT attempt to install packages. Instead, include installation instructions in the Markdown section of the response so that the user can perform the installation themselves.
-* **CRITICAL**: Before running code, just acknowledge with a brief phrase like "On it", "Let me check", or "Running that now". After the code runs and you see the results, provide the most important tidbit learned in one sentence or less, wrapped in `<insight>` tags, like: `<insight>The dataset contains 150 rows with no missing values.</insight>`
+* **CRITICAL**: DO NOT announce that you're going to run code or describe what you're about to do. Simply run the code using the `_intent` parameter to briefly describe the action. After the code runs and you see the results, provide the most important tidbit learned in one sentence or less, wrapped in `<insight>` tags, like: `<insight>The dataset contains 150 rows with no missing values.</insight>`. Always ensure you close the insight tag with `</insight>` before running another tool or continuing.
 
 ## Exploring data
 

--- a/inst/www/lightbulb-outline.svg
+++ b/inst/www/lightbulb-outline.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+  <path d="M8 1.5C5.79 1.5 4 3.29 4 5.5C4 6.88 4.64 8.11 5.64 8.86C5.86 9.03 6 9.28 6 9.55V11.5C6 11.78 6.22 12 6.5 12H9.5C9.78 12 10 11.78 10 11.5V9.55C10 9.28 10.14 9.03 10.36 8.86C11.36 8.11 12 6.88 12 5.5C12 3.29 10.21 1.5 8 1.5Z" stroke="#2196f3" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M6.5 13H9.5" stroke="#2196f3" stroke-width="1.2" stroke-linecap="round"/>
+  <path d="M6.5 14H9.5" stroke="#2196f3" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/inst/www/style.css
+++ b/inst/www/style.css
@@ -3,17 +3,27 @@
 }
 
 .summary-insight {
-  padding: 8px 12px;
+  padding: 8px 12px 8px 28px;
   background: #f0f8ff;
   border-left: 3px solid #2196f3;
-  margin: 8px 0;
+  margin: 8px 0 16px 0;
   display: flex;
   align-items: center;
-  gap: 8px;
+  border-radius: 4px;
+  position: relative;
 }
 
-.summary-insight i {
-  color: #2196f3;
+.summary-insight::before {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 8px;
+  width: 14px;
+  height: 14px;
+  background-image: url('lightbulb-outline.svg');
+  background-size: contain;
+  background-repeat: no-repeat;
+  opacity: 0.5;
 }
 
 details {

--- a/inst/www/style.css
+++ b/inst/www/style.css
@@ -7,19 +7,39 @@
   background: #f0f8ff;
   border-left: 3px solid #2196f3;
   margin: 8px 0 16px 0;
-  display: flex;
-  align-items: center;
+  display: block;
   border-radius: 4px;
   position: relative;
+  overflow: hidden;
+}
+
+.summary-insight img {
+  max-width: 100%;
+  max-height: 350px;
+  width: auto;
+  height: auto;
+  display: block !important;
+  margin-bottom: 8px;
+  border-radius: 8px;
+  float: none !important;
+  object-fit: contain;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.summary-insight .insight-text {
+  display: block !important;
+  clear: both;
+  width: 100%;
+  margin-top: 8px;
 }
 
 .summary-insight::before {
   content: "";
   position: absolute;
-  top: 4px;
+  top: 6px;
   left: 8px;
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   background-image: url('lightbulb-outline.svg');
   background-size: contain;
   background-repeat: no-repeat;
@@ -28,29 +48,40 @@
 
 details {
   margin-top: 8px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background: white;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 summary {
-  padding: 8px;
-  background: #f9f9f9;
+  padding: 10px 12px;
+  background: white;
   cursor: pointer;
   user-select: none;
+  border-radius: 6px;
+  font-weight: 500;
+  color: #333;
 }
 
 summary:hover {
-  background: #f0f0f0;
+  background: #f8f9fa;
 }
 
 details[open] summary {
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid #e0e0e0;
+  border-radius: 6px 6px 0 0;
+}
+
+details[open] {
+  padding-bottom: 8px;
 }
 
 .code-block, .output-block {
-  margin: 8px;
-  padding: 8px;
-  background: #f5f5f5;
+  margin: 8px 12px;
+  padding: 10px;
+  background: #f8f9fa;
   border-radius: 4px;
   overflow-x: auto;
+  border: 1px solid #e9ecef;
 }

--- a/inst/www/style.css
+++ b/inst/www/style.css
@@ -1,3 +1,46 @@
 .data-frame {
   font-size: 0.875em;
 }
+
+.summary-insight {
+  padding: 8px 12px;
+  background: #f0f8ff;
+  border-left: 3px solid #2196f3;
+  margin: 8px 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.summary-insight i {
+  color: #2196f3;
+}
+
+details {
+  margin-top: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+summary {
+  padding: 8px;
+  background: #f9f9f9;
+  cursor: pointer;
+  user-select: none;
+}
+
+summary:hover {
+  background: #f0f0f0;
+}
+
+details[open] summary {
+  border-bottom: 1px solid #ddd;
+}
+
+.code-block, .output-block {
+  margin: 8px;
+  padding: 8px;
+  background: #f5f5f5;
+  border-radius: 4px;
+  overflow-x: auto;
+}

--- a/memory.md
+++ b/memory.md
@@ -1,0 +1,292 @@
+# Databot Multi-Agent Architecture Design
+
+The user provided the following request:
+
+
+> Currently, databot uses one agent, who both communicates with the user (the "greeter") and executes code and interprets > analyses (the "coder"). This can be a bit overwhelming for the user, as the agent generates a lot of code and output, usually > far more than the user is able to interpret. I would like to split databot up into two (or more) agents.
+> 
+> * The greeter is the agent that databot talks to. The agent, very importantly, says very little and only surfaces the most > information-dense learnings from the coder.
+> * The coder writes code, looks at the results, and decides what code to write next. We still want it to give up control > occasionally so that the user can interject. 
+> 
+> Important questions:
+> 
+> * How do the greeter and coder communicate? It _could_ be a "hook" inside of `run_r_code()`, it could be the file system, etc. > Consider both directions.
+> * Should there be only one coder? Or should coders be "ephemeral" agents that are spawned every time a user sends a request to > the greeter?
+> * Ultimately, we'd like insights from the coder to proliferate up to the user every time `run_r_code()` is invoked, based on the current conversation history and the code output, summarized down to less than a sentence. When plots are generated via R code, we probably want them to proliferate up automatically (and have the greeter or a summarizing agent caption the image > with a sentence.)
+> * Currently, one main benefit of the current approach is verifiability; the user can see all of the code being streamed in and critique it as it does (as long as they can keep up). How can we preserve this verifiability? I think, ultimately, when > `run_r_code()` calls are summarized, we want users to be able to "click in" to the summaries and read the full source code.
+> 
+> Other considerations:
+> 
+>  1) For speed, I think it's important that both the greeter and the coder  receive requests at the same time. (Or the coder only—maybe the greeter doesn't even need to see it.)                      
+> 2) I think `run_r_code()` should still just return the results as-is, but right before it returns it also has a hook to send the results to the greeter (or to a summarizer agent that has access to the UI). Onlythen would the summarizing happen—this way, the coder can just see the results of the code it ran and keep iterating, as it does currently.
+
+
+## Overview
+
+Split databot from one overwhelming agent into a cleaner multi-agent system:
+- **Coder**: Autonomous code executor that iterates on analysis
+- **Summarizer**: Digests code outputs into one-sentence insights
+- **UI**: Progressive disclosure interface for verifiability
+
+## Key Design Principles
+
+1. **Parallel execution**: Coder starts immediately when user submits request
+2. **Hook-based summarization**: `run_r_code()` triggers summarizer via async hook
+3. **Non-blocking**: Summarizer runs in background, doesn't slow down coder
+4. **Verifiability**: Full code/output available via expandable UI elements
+
+## Architecture Flow
+
+```
+User Input
+    ↓
+    ├─→ Greeter (acknowledges only)
+    │     ↓
+    │   "Let me analyze this..."
+    │
+    └─→ Coder (via mirai)
+          ↓
+        run_r_code("analysis code")
+          ↓
+          ├─→ Returns raw results to Coder (immediate)
+          │     ↓
+          │   Coder continues iterating
+          │
+          └─→ Triggers Summarizer (async hook)
+                ↓
+              Summarizer analyzes output
+                ↓
+              Updates UI with insight
+```
+
+## Core Implementation
+
+### 1. Parallel Request Handling
+
+```r
+# In app.R server function
+observeEvent(input$chat_user_input, {
+  user_input <- input$chat_user_input
+  
+  # Greeter just acknowledges immediately
+  chat_append_message("chat", list(
+    role = "assistant", 
+    content = "Let me analyze this for you..."
+  ))
+  
+  # Coder gets to work immediately in parallel
+  coder_task <- ExtendedTask$new(function(input) {
+    mirai({
+      coder <- chat_anthropic(coder_prompt, echo = FALSE)
+      coder$register_tool(tool(
+        run_r_code,  # Still returns raw results to coder
+        "Executes R code in the current session",
+        arguments = list(code = type_string("R code to execute"))
+      ))
+      
+      # Coder works autonomously
+      coder$chat(input)
+    })
+  })
+  
+  coder_task$invoke(user_input)
+})
+```
+
+### 2. Hook-Based Summarization in `run_r_code()`
+
+```r
+# Modified tools.R
+run_r_code <- function(code) {
+  # Existing code execution logic...
+  result <- evaluate_r_code(code, ...)
+  
+  # NEW: Hook to summarizer agent (async, non-blocking)
+  summarize(
+    code = code,
+    output = result,
+    context = get_current_conversation_context()
+  )
+  
+  # Return immediately to coder (unchanged behavior)
+  I(result)
+}
+
+# New function to trigger summarizer
+summarize <- function(code, output, context) {
+  # This runs async via mirai, doesn't block the coder
+  summarizer_task <- ExtendedTask$new(function(c, o, ctx) {
+    mirai({
+      summarizer <- chat_anthropic(
+        system_prompt = "You are a concise data science summarizer. 
+                        Summarize code outputs in one sentence or less.
+                        For plots, provide a one-sentence caption.",
+        echo = FALSE
+      )
+      
+      summary <- summarizer$chat_structured(
+        paste("Summarize this output:", o),
+        type = type_object(
+          insight = type_string("One sentence summary"),
+          plot_caption = type_string("Caption if plot exists, else null"),
+          importance = type_enum("high", "medium", "low")
+        )
+      )
+      
+      summary
+    })
+  })
+  
+  # Fire and forget - results handled via promise
+  summarizer_task$invoke(code, output, context) %...>% {
+    # When summary is ready, update UI
+    update_message_with_summary(.)
+  }
+}
+```
+
+### 3. Progressive Disclosure UI
+
+```r
+# Helper to update existing message with summary
+update_message_with_summary <- function(summary) {
+  # Create collapsible UI element
+  summary_ui <- tagList(
+    div(class = "summary-insight",
+      icon("lightbulb"),
+      span(summary$insight)
+    ),
+    if (!is.null(summary$plot_caption)) {
+      p(class = "plot-caption", summary$plot_caption)
+    },
+    # Collapsible details with original code/output
+    details(
+      summary("View code and full output"),
+      pre(class = "code-block", summary$code),
+      pre(class = "output-block", summary$output)
+    )
+  )
+  
+  # Append to chat (or update last message)
+  chat_append_message("chat", list(
+    role = "assistant",
+    content = summary_ui
+  ))
+}
+```
+
+## Implementation Steps
+
+### Phase 1: Hook Infrastructure
+
+1. **Modify `run_r_code()` in tools.R**
+   ```r
+   run_r_code_with_hooks <- function(code) {
+     # Store context for summarizer
+     store_execution_context(code)
+     
+     # Execute normally
+     result <- run_r_code(code)
+     
+     # Trigger async summarization
+     spawn_summarizer(code, result)
+     
+     # Return immediately to coder
+     result
+   }
+   ```
+
+2. **Create summarizer spawning logic**
+   ```r
+   spawn_summarizer <- function(code, result) {
+     # Don't block - use promises
+     promises::promise(function(resolve, reject) {
+       m <- mirai({
+         # Summarize in background
+         create_summary(code, result)
+       })
+       resolve(m)
+     }) %...>% {
+       # Update UI when ready
+       append_summary_to_chat(.)
+     }
+   }
+   ```
+
+### Phase 2: Agent System
+
+1. **Update `chat_bot()` to register enhanced tool**
+   ```r
+   chat_bot <- function(system_prompt = NULL, default_turns = list()) {
+     # ... existing code ...
+     
+     # Register hook-enabled run_r_code
+     chat$register_tool(tool(
+       run_r_code_with_hooks,  # New wrapper function
+       "Executes R code in the current session",
+       arguments = list(code = type_string("R code to execute"))
+     ))
+   }
+   ```
+
+2. **Implement parallel agent spawning in app.R**
+
+### Phase 3: UI Enhancements
+
+1. **Add expandable details components**
+   - Use `bslib::accordion()` or custom `details/summary` tags
+   - Store full outputs in reactive values indexed by message ID
+   - Add "expand/collapse all" controls
+
+2. **Style summary components**
+   ```css
+   .summary-insight {
+     padding: 8px 12px;
+     background: #f0f8ff;
+     border-left: 3px solid #2196f3;
+     margin: 8px 0;
+   }
+   
+   .plot-caption {
+     font-style: italic;
+     color: #666;
+     margin-top: 4px;
+   }
+   
+   details {
+     margin-top: 8px;
+     border: 1px solid #ddd;
+     border-radius: 4px;
+   }
+   
+   summary {
+     padding: 8px;
+     background: #f9f9f9;
+     cursor: pointer;
+   }
+   ```
+
+## Benefits
+
+- **Speed**: Coder starts immediately, no waiting for greeter
+- **Clarity**: Users see condensed insights, not overwhelming code dumps
+- **Verifiability**: All code/output accessible via progressive disclosure
+- **Scalability**: Can spawn multiple agents as needed
+- **Non-blocking**: Summarization doesn't slow down analysis
+- **Better UX**: Clean interface with details on demand
+
+## Technical Notes
+
+- Use **mirai** for parallel agent execution
+- Use **ExtendedTask** for async Shiny integration
+- Use **promises** for non-blocking UI updates
+- Maintain existing `run_r_code()` contract for coder
+- Add hook system that doesn't break existing functionality
+
+## Future Enhancements
+
+- **Multiple coders**: Spawn specialized coders for different analysis types
+- **Smart routing**: Direct different question types to appropriate agents  
+- **Context awareness**: Summarizer understands full conversation history
+- **Interactive summaries**: Let users refine or expand insights
+- **Caching**: Avoid re-summarizing identical code outputs


### PR DESCRIPTION
Totally vibe-coded--not intended to be merged.

This follows up on some conversations 1) where folks mention the overwhelm of tokens streaming in while using databot and 2) about whether databot might be improved by any sort of multi-agent tomfoolery. I wondered if we could use multiple agents to make the experience of using databot less overwhelming while also preserving the "auditability" of databot's work.

In many ways, the resulting interface ending up just looking like a default shinychat instance with a `run_r_code()` tool, but pairing that tool with databot's MarkdownStreamer inside the collapsibles makes reading the tool call internals much more pleasant. This also didn't end up using multiple agents—will leave a comment where I pushed the spec of how I thought this might happen but ultimately ended up abandoning.

https://github.com/user-attachments/assets/120f8ca6-e137-45ce-b75c-9d20ef555814

